### PR TITLE
Add CLI tool for database setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,28 @@ go get github.com/yuku/numpool
 
 ### 1. Set up the database
 
-First, initialize the required database table:
+First, initialize the required database table. You can do this either via CLI or programmatically:
+
+#### Via CLI:
+
+```bash
+# Using go run
+go run github.com/yuku/numpool/cmd/numpool setup
+
+# Or install the binary first
+go install github.com/yuku/numpool/cmd/numpool@latest
+numpool setup
+```
+
+The CLI respects standard PostgreSQL environment variables:
+- `DATABASE_URL`: Full connection string
+- `PGHOST`: Database host (default: localhost)
+- `PGPORT`: Database port (default: 5432)
+- `PGUSER`: Database user (default: postgres)
+- `PGPASSWORD`: Database password
+- `PGDATABASE`: Database name (default: postgres)
+
+#### Programmatically:
 
 ```go
 import (

--- a/cmd/numpool/main.go
+++ b/cmd/numpool/main.go
@@ -1,0 +1,77 @@
+// Command numpool provides CLI utilities for managing numpool database schema.
+//
+// Usage:
+//   numpool <command>
+//
+// Commands:
+//   setup    Initialize the numpool database schema
+//
+// The numpool command respects standard PostgreSQL environment variables:
+//   - DATABASE_URL: Full connection string (overrides all other variables)
+//   - PGHOST: Database host (default: localhost)
+//   - PGPORT: Database port (default: 5432)
+//   - PGUSER: Database user (default: postgres)
+//   - PGPASSWORD: Database password (default: postgres)
+//   - PGDATABASE: Database name (default: postgres)
+//
+// Example:
+//   # Using DATABASE_URL
+//   DATABASE_URL=postgres://user:pass@host:5432/db numpool setup
+//
+//   # Using individual variables
+//   PGHOST=db.example.com PGUSER=myuser PGPASSWORD=mypass numpool setup
+//
+//   # Using defaults (connects to localhost:5432 as postgres user)
+//   numpool setup
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/yuku/numpool"
+	"github.com/yuku/numpool/internal"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: %s <command>\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "Commands:\n")
+		fmt.Fprintf(os.Stderr, "  setup    Initialize the numpool database schema\n")
+		os.Exit(1)
+	}
+
+	command := os.Args[1]
+
+	switch command {
+	case "setup":
+		if err := runSetup(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println("Setup completed successfully")
+	default:
+		fmt.Fprintf(os.Stderr, "Unknown command: %s\n", command)
+		os.Exit(1)
+	}
+}
+
+// runSetup initializes the numpool database schema.
+// It uses internal.GetConnection which automatically reads PostgreSQL
+// connection parameters from environment variables.
+func runSetup() error {
+	ctx := context.Background()
+
+	conn, err := internal.GetConnection(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = conn.Close(ctx) }()
+
+	if err := numpool.Setup(ctx, conn); err != nil {
+		return fmt.Errorf("failed to setup database: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary
- Added `cmd/numpool/main.go` with a CLI tool for database setup
- Implemented `numpool setup` command to initialize the database schema
- Reused `internal.GetConnection` to avoid code duplication

## Usage
The CLI can be used in two ways:

```bash
# Direct execution with go run
go run github.com/yuku/numpool/cmd/numpool setup

# Or install and run
go install github.com/yuku/numpool/cmd/numpool@latest
numpool setup
```

## Configuration
The CLI respects standard PostgreSQL environment variables:
- `DATABASE_URL`: Full connection string (overrides all other variables)
- `PGHOST`: Database host (default: localhost)
- `PGPORT`: Database port (default: 5432)
- `PGUSER`: Database user (default: postgres)
- `PGPASSWORD`: Database password
- `PGDATABASE`: Database name (default: postgres)

## Test plan
- [x] Tested `go run github.com/yuku/numpool/cmd/numpool setup` - works correctly
- [x] Tested help message display
- [x] Verified linter passes with no issues
- [x] Updated README.md with CLI usage instructions

🤖 Generated with [Claude Code](https://claude.ai/code)