### PR TITLE
Add Husky pre-commit hooks for code quality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,10 @@
+echo "Running pre-commit hooks..."
+
+echo "go fmt"
+go fmt
+
+echo "golangci-lint run"
+golangci-lint run
+
+echo "go test"
+go test -timeout 10s -race ./...

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "numpool",
+  "private": true,
+  "scripts": {
+    "prepare": "husky"
+  },
+  "license": "MIT",
+  "packageManager": "pnpm@10.12.2",
+  "devDependencies": {
+    "husky": "^9.1.7"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,24 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
+
+packages:
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+snapshots:
+
+  husky@9.1.7: {}


### PR DESCRIPTION
## Summary
- Set up Husky with pnpm for automated pre-commit hooks
- Configure pre-commit hooks to run go fmt, golangci-lint, and tests
- Ensure code quality checks run automatically before each commit

## Test plan
- [x] Verify Husky is properly configured in package.json
- [x] Confirm pre-commit hook runs go fmt, golangci-lint, and tests
- [x] Test that commits are blocked if any checks fail
- [ ] Run `pnpm install` to install Husky after merging

🤖 Generated with [Claude Code](https://claude.ai/code)