### PR TITLE
Add standalone Cleanup function for database cleanup

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -268,17 +268,20 @@ func (m *Manager) Delete(ctx context.Context, poolID string) error {
 	return nil
 }
 
+// Cleanup drops the numpool table in the database.
+// It is used to clean up the database schema when the manager is no longer needed.
+func Cleanup(ctx context.Context, pool *pgxpool.Pool) error {
+	if err := sqlc.New(pool).DropNumpoolTable(ctx); err != nil {
+		return fmt.Errorf("failed to drop numpool table: %w", err)
+	}
+	return nil
+}
+
 // Cleanup removes all Numpool instances managed by this manager.
 // It drops the numpool table in the database if it exists.
 func (m *Manager) Cleanup(ctx context.Context) error {
 	if !m.Closed() {
 		m.Close()
 	}
-
-	// Drop the numpool table in the database
-	if err := sqlc.New(m.pool).DropNumpoolTable(ctx); err != nil {
-		return fmt.Errorf("failed to drop numpool table: %w", err)
-	}
-
-	return nil
+	return Cleanup(ctx, m.pool)
 }

--- a/manager_test.go
+++ b/manager_test.go
@@ -370,6 +370,26 @@ func TestManager_Close(t *testing.T) {
 	})
 }
 
+func TestCleanup(t *testing.T) {
+	ctx := context.Background()
+	pool := internal.MustGetPoolWithCleanup(t)
+
+	// Given: a manager setup with a connection pool
+	_, err := numpool.Setup(ctx, pool)
+	require.NoError(t, err, "Setup should not return an error")
+	exists, err := sqlc.New(pool).CheckNumpoolTableExist(ctx)
+	require.NoError(t, err, "CheckNumpoolTableExist should not return an error")
+	assert.True(t, exists, "Numpool table should not exist after Cleanup")
+
+	// When: cleanup the manager
+	require.NoError(t, numpool.Cleanup(ctx, pool))
+
+	// Then: that the numpools table is dropped
+	exists, err = sqlc.New(pool).CheckNumpoolTableExist(ctx)
+	require.NoError(t, err, "CheckNumpoolTableExist should not return an error")
+	assert.False(t, exists, "Numpool table should not exist after Cleanup")
+}
+
 func TestManager_Cleanup(t *testing.T) {
 	ctx := context.Background()
 	pool := internal.MustGetPoolWithCleanup(t)


### PR DESCRIPTION
## Summary
- Adds a package-level `Cleanup(ctx, pool)` function for flexible database cleanup
- Refactors `Manager.Cleanup()` to use the new standalone function internally
- Provides better separation of concerns and allows cleanup without Manager instance

## Test plan
- [x] Add new test `TestCleanup` that verifies standalone cleanup functionality
- [x] Verify existing `TestManager_Cleanup` still passes with refactored implementation
- [x] Run full test suite to ensure no regressions
- [x] Verify pre-commit hooks pass (formatting, linting, tests)

🤖 Generated with [Claude Code](https://claude.ai/code)