### PR TITLE
Add WithLock method for exclusive execution across pool instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+settings.local.json

--- a/README.md
+++ b/README.md
@@ -206,6 +206,13 @@ if pool.Closed() {
     log.Println("Pool is closed")
 }
 
+// Run a function exclusively across all pool instances with the same ID
+err := pool.WithLock(ctx, func() error {
+    // This function runs exclusively - only one instance
+    // across all processes can execute this at a time
+    return doSomethingExclusive()
+})
+
 // Manually close a pool (stops listening and releases resources)
 pool.Close()
 ```


### PR DESCRIPTION
## Summary
- Add `WithLock` method to `Numpool` for distributed mutual exclusion
- Update README.md with usage documentation and examples
- Add comprehensive test case validating exclusive execution across multiple pool instances

## Test plan
- [x] Unit tests pass (`go test -race ./...`)
- [x] Linting passes (`golangci-lint run`)
- [x] Formatting checks pass (`go fmt`)
- [x] Test case validates exclusive execution using shared counter across 5 goroutines
- [x] Method uses PostgreSQL row-level locking for distributed coordination

🤖 Generated with [Claude Code](https://claude.ai/code)